### PR TITLE
api: Add Instrumentation API

### DIFF
--- a/include/zsl/instrumentation.h
+++ b/include/zsl/instrumentation.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Kevin Townsend
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
+#define ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H__
+
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <zsl/zsl.h>
+
+/**
+ * @brief Reads the high-precision timer start time.
+ */
+#define ZSL_INSTR_START(t) do {	      \
+		t = k_cycle_get_32(); \
+} while (0);
+
+/**
+ * @brief Reads the high-precision timer stop time and converts to ns. This
+ *        function modifies the value of t to store the execution time in ns.
+ */
+#define ZSL_INSTR_STOP(t) do {				      \
+		uint32_t end = k_cycle_get_32();	      \
+		t = end < t ? 0xFFFFFFFF - t + end : end - t; \
+		t = k_cyc_to_ns_floor32(t);		      \
+} while (0);
+
+#endif /* ZEPHYR_INCLUDE_ZSL_INSTRUMENTATION_H_ */


### PR DESCRIPTION
This commit adds an optional instrumentation header file that
provides approximate execution times for larger chunks of code.
It is based on the high-precision timer in Zephyr, so isn't as
granular or accurate as something like DWT on the M3/M4/M7/M33,
but is platform-agnostic.

It updates the benchmarking sample to use this new header.

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>